### PR TITLE
修复只替换第一处 `.wxss` 的 bug

### DIFF
--- a/lib/wxmp2antmp.js
+++ b/lib/wxmp2antmp.js
@@ -16,7 +16,7 @@ function to (from, to) {
             if (err) throw err;
         });
     } else if (/\.wxss$/i.test(from)) {
-        file = file.replace('.wxss"', '.acss"').replace('.wxss\'', '.acss\'');
+        file = file.replace(new RegExp('.wxss"', 'g'), '.acss"').replace(new RegExp('.wxss\'', 'g'), '.acss\'');
         fs.writeFile(to, file, function (err) {
             if (err) throw err;
         });


### PR DESCRIPTION
没写成正则，只替换了一处。